### PR TITLE
refactor: output is now pure markdown

### DIFF
--- a/cmd/kagi/main.go
+++ b/cmd/kagi/main.go
@@ -53,26 +53,22 @@ func run(args []string) error {
 	return nil
 }
 
-func respond(resp *api.FastGPTResponse, query string) string {
-	answer := resp.Data.Output
+func respond(resp *api.FastGPTResponse, query string) (response string) {
 	// remove all repeated newlines or empty lines from the output
-	answer = strings.ReplaceAll(answer, "\n\n", "\n")
+  answer := strings.ReplaceAll(resp.Data.Output, "\n\n", "\n")
 
-	fmt.Println("# " + query)
-	fmt.Println(answer)
+  response = "# " + query + "\n" + answer + "\n"
 
 	// If there are no references, return early
 	if len(resp.Data.References) == 0 {
-		return answer
+		return
 	}
 
-	fmt.Println()
-	fmt.Println("# References")
-	fmt.Println()
+  response += "\n# References\n"
 
 	for i, ref := range resp.Data.References {
-		fmt.Printf("%d. %s - %s  - %s\n", i+1, ref.Title, ref.Link, ref.Snippet)
+    response += fmt.Sprintf("%d. %s - %s  - %s\n", i+1, ref.Title, ref.Link, ref.Snippet)
 	}
 
-	return answer
+	return
 }

--- a/cmd/kagi/main.go
+++ b/cmd/kagi/main.go
@@ -47,16 +47,32 @@ func run(args []string) error {
 		return fmt.Errorf("error performing query: %w", err)
 	}
 
-	fmt.Println("===== OUTPUT =====")
+	response := respond(resp, query)
+	fmt.Print(response)
+
+	return nil
+}
+
+func respond(resp *api.FastGPTResponse, query string) string {
+	answer := resp.Data.Output
+	// remove all repeated newlines or empty lines from the output
+	answer = strings.ReplaceAll(answer, "\n\n", "\n")
+
+	fmt.Println("# " + query)
+	fmt.Println(answer)
+
+	// If there are no references, return early
+	if len(resp.Data.References) == 0 {
+		return answer
+	}
+
 	fmt.Println()
-	fmt.Println(resp.Data.Output)
-	fmt.Println()
-	fmt.Println("===== REFERENCES =====")
+	fmt.Println("# References")
 	fmt.Println()
 
 	for i, ref := range resp.Data.References {
-		fmt.Printf("%d. %s - %s\n  - %s\n\n", i+1, ref.Title, ref.Link, ref.Snippet)
+		fmt.Printf("%d. %s - %s  - %s\n", i+1, ref.Title, ref.Link, ref.Snippet)
 	}
 
-	return nil
+	return answer
 }


### PR DESCRIPTION
This can now be easily piped to `glow` to become a very useful terminal-based search tool

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/28fb5018-469f-4ddc-b4a1-2ea28612754d" />
